### PR TITLE
Pihsm configurable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,12 @@ fn buildchain() -> Result<(), String> {
             SubCommand::with_name("build")
                 .about("Build a buildchain project")
                 .arg(
+                    Arg::with_name("pihsm")
+                        .short("p")
+                        .long("pihsm")
+                        .help("Sign manifest with PiHSM")
+                )
+                .arg(
                     Arg::with_name("config")
                         .short("c")
                         .long("config")

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ fn buildchain() -> Result<(), String> {
             SubCommand::with_name("build")
                 .about("Build a buildchain project")
                 .arg(
-                    Arg::with_name("pihsm")
+                    Arg::with_name("use_pihsm")
                         .short("p")
                         .long("pihsm")
                         .help("Sign manifest with PiHSM")
@@ -58,6 +58,7 @@ fn buildchain() -> Result<(), String> {
             remote_opt: matches.value_of("remote"),
             source_url: matches.value_of("source_url").unwrap_or("."),
             source_kind: matches.value_of("source_kind").unwrap_or("dir"),
+            use_pihsm: matches.is_present("use_pihsm"),
         })
     } else {
         Err(format!("no subcommand provided"))


### PR DESCRIPTION
Adds --pihsm option to build subcommand, which causes the manifest to be signed by PiHSM.

By default build will not sign the manifest using PiHSM now.