### PR TITLE
tar: Exclude VCS files from the archive

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -140,6 +140,7 @@ fn archive<P: AsRef<Path>, Q: AsRef<Path>>(source_path: P, dest_path: Q) -> io::
         .arg("--owner=0")
         .arg("--group=0")
         .arg("--numeric-owner")
+        .arg("--exclude-vcs")
         .arg("--file")
         .arg(dest_path)
         .arg("--directory")


### PR DESCRIPTION
On an LFS enabled repo, files in `.git/lfs` can take up substantial space in the tarball. More generally, there is no reason to include the VCS directory in an archive as any git information should be provided by the source repo.