### PR TITLE
build: Simplify logic

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -193,7 +193,7 @@ pub fn build(args: BuildArguments) -> Result<(), String> {
         }
     };
 
-    let mut file = match File::open(&source_path.join(&config_path)) {
+    let mut file = match File::open(source_path.join(config_path)) {
         Ok(file) => file,
         Err(err) => {
             return Err(format!("failed to open config {}: {}", config_path, err));
@@ -235,7 +235,7 @@ pub fn build(args: BuildArguments) -> Result<(), String> {
         &location,
         &build_image,
         &source_path,
-        &temp_dir.path(),
+        temp_dir.path(),
     ) {
         Ok(()) => (),
         Err(err) => {
@@ -263,7 +263,7 @@ pub fn build(args: BuildArguments) -> Result<(), String> {
     }
     store.remove_tmp_dir()?;
 
-    match archive(&temp_dir, &args.output_path) {
+    match archive(&temp_dir, args.output_path) {
         Ok(()) => {
             println!("buildchain: placed results in {}", args.output_path);
         }

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use serde::{Deserialize, Serialize};
-use std::fs::File;
-use std::io::{self, Read};
+use std::fs;
+use std::io;
 use std::path::Path;
 use std::process::Command;
 
@@ -193,20 +193,10 @@ pub fn build(args: BuildArguments) -> Result<(), String> {
         }
     };
 
-    let mut file = match File::open(source_path.join(config_path)) {
-        Ok(file) => file,
-        Err(err) => {
-            return Err(format!("failed to open config {}: {}", config_path, err));
-        }
+    let string = match fs::read_to_string(source_path.join(config_path)) {
+        Ok(f) => f,
+        Err(err) => return Err(format!("failed to read config {}: {}", config_path, err)),
     };
-
-    let mut string = String::new();
-    match file.read_to_string(&mut string) {
-        Ok(_) => (),
-        Err(err) => {
-            return Err(format!("failed to read config {}: {}", config_path, err));
-        }
-    }
 
     let config = match serde_json::from_str::<Config>(&string) {
         Ok(config) => config,

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,7 @@ fn buildchain() -> Result<(), String> {
             source_kind: matches.value_of("source_kind").unwrap_or("dir"),
             use_pihsm: matches.is_present("use_pihsm"),
         })
+        .map_err(|err| format!("failed to build: {}", err))
     } else if let Some(matches) = matches.subcommand_matches("download") {
         download(DownloadArguments {
             project: matches.value_of("project").unwrap_or("default"),

--- a/src/source.rs
+++ b/src/source.rs
@@ -70,7 +70,7 @@ impl Source {
                             io::ErrorKind::Other,
                             format!("Find time not a number: {}", err),
                         )
-                    })? as u64;
+                    })?;
 
                     time_opt = match time_opt {
                         Some(old_time) => {


### PR DESCRIPTION
Use some conveniences to reduce the noise.

- `fs::read_to_string`
- `map_err()` instead of full `match` blocks
- Replace custom `Result<T, String>` with `io::Result<T>`