### PR TITLE
Update deps.sh

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -1,2 +1,7 @@
-#!/bin/bash
-sudo apt install lxd lxd-client
+#!/bin/sh
+
+sudo apt -q update
+sudo apt -q install --no-install-recommends --yes \
+    build-essential \
+    libssl-dev \
+    pkgconf


### PR DESCRIPTION
Add build dependencies for a fresh Ubuntu install.

LXD is no longer provided as a package, and is only available as a snap. An "lxd-installer" transitional package will automatically install the snap when a user tries to run LXD.