### PR TITLE
Add option to exclude source checkout from tarball

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,105 +3,105 @@
 #![allow(clippy::uninlined_format_args)]
 
 use buildchain::{build, download, BuildArguments, DownloadArguments};
-use clap::{App, Arg, SubCommand};
+use clap::{App, Arg};
 use std::process;
 
 fn buildchain() -> Result<(), String> {
     let matches = App::new("buildchain")
         .subcommand(
-            SubCommand::with_name("build")
+            App::new("build")
                 .about("Build a buildchain project")
                 .arg(
-                    Arg::with_name("use_pihsm")
+                    Arg::new("use_pihsm")
                         .short('p')
                         .long("pihsm")
                         .help("Sign manifest with PiHSM"),
                 )
                 .arg(
-                    Arg::with_name("config")
+                    Arg::new("config")
                         .short('c')
                         .long("config")
                         .takes_value(true)
                         .help("Configuration file"),
                 )
                 .arg(
-                    Arg::with_name("output")
+                    Arg::new("output")
                         .short('o')
                         .long("output")
                         .takes_value(true)
                         .help("Output directory"),
                 )
                 .arg(
-                    Arg::with_name("project")
+                    Arg::new("project")
                         .long("project")
                         .takes_value(true)
                         .help("Tail signature project name"),
                 )
                 .arg(
-                    Arg::with_name("branch")
+                    Arg::new("branch")
                         .long("branch")
                         .takes_value(true)
                         .help("Tail signature branch name"),
                 )
                 .arg(
-                    Arg::with_name("remote")
+                    Arg::new("remote")
                         .short('r')
                         .long("remote")
                         .takes_value(true)
                         .help("Remote LXC server"),
                 )
                 .arg(
-                    Arg::with_name("source_url")
+                    Arg::new("source_url")
                         .takes_value(true)
                         .help("Source URL"),
                 )
                 .arg(
-                    Arg::with_name("source_kind")
+                    Arg::new("source_kind")
                         .takes_value(true)
                         .help("Source Kind (dir, git)"),
                 ),
         )
         .subcommand(
-            SubCommand::with_name("download")
+            App::new("download")
                 .about("Download from a buildchain project")
                 .arg(
-                    Arg::with_name("project")
+                    Arg::new("project")
                         .long("project")
                         .takes_value(true)
                         .help("Tail signature project name"),
                 )
                 .arg(
-                    Arg::with_name("branch")
+                    Arg::new("branch")
                         .long("branch")
                         .takes_value(true)
                         .help("Tail signature branch name"),
                 )
                 .arg(
-                    Arg::with_name("cert")
+                    Arg::new("cert")
                         .long("cert")
                         .takes_value(true)
                         .help("Remote URL certificate"),
                 )
                 .arg(
-                    Arg::with_name("cache")
+                    Arg::new("cache")
                         .long("cache")
                         .takes_value(true)
                         .help("Local cache"),
                 )
                 .arg(
-                    Arg::with_name("key")
+                    Arg::new("key")
                         .takes_value(true)
                         .required(true)
                         .help("Remote public key"),
                 )
                 .arg(
-                    Arg::with_name("url")
+                    Arg::new("url")
                         .takes_value(true)
                         .required(true)
                         .help("Remote URL"),
                 )
                 .arg(
-                    Arg::with_name("file")
+                    Arg::new("file")
                         .takes_value(true)
                         .help("Requested file"),
                 ),

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use std::process;
 
 fn buildchain() -> Result<(), String> {
     let matches = App::new("buildchain")
+        .version(env!("CARGO_PKG_VERSION"))
         .subcommand(
             App::new("build")
                 .about("Build a buildchain project")

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,11 @@ fn buildchain() -> Result<(), String> {
                     Arg::new("source_kind")
                         .takes_value(true)
                         .help("Source Kind (dir, git)"),
+                )
+                .arg(
+                    Arg::new("exclude_source")
+                        .long("exclude-source")
+                        .help("Exclude the source checkout from the archive"),
                 ),
         )
         .subcommand(
@@ -119,6 +124,7 @@ fn buildchain() -> Result<(), String> {
             source_url: matches.value_of("source_url").unwrap_or("."),
             source_kind: matches.value_of("source_kind").unwrap_or("dir"),
             use_pihsm: matches.is_present("use_pihsm"),
+            exclude_source: matches.is_present("exclude_source"),
         })
         .map_err(|err| format!("failed to build: {}", err))
     } else if let Some(matches) = matches.subcommand_matches("download") {


### PR DESCRIPTION
In the case of generating the System76 firmware buildchain, the source checkout is not used for anything after generating the artifacts. This option will reduce the size of the tarball by ~78% (3,836,559,360 bytes to 834,611,200 bytes).